### PR TITLE
Ensure to-do input text is visible in dark mode

### DIFF
--- a/todolist_example_component/components/ToDoList/main.scss
+++ b/todolist_example_component/components/ToDoList/main.scss
@@ -24,7 +24,6 @@
     font: inherit;
     padding: 10px 24px;
     border-radius: 8px;
-    color: black;
   }
 
   button {


### PR DESCRIPTION
For browsers configured in dark mode, input text is currently black-on-black, rendering to-do input invisible.

This PR removes the relevant style from the example so that the built-in style is used instead, respective to either mode.

![CleanShot 2024-09-10 at 16 16 19@2x](https://github.com/user-attachments/assets/b5c4aae6-17c2-4309-bdcc-cb4a37dd3b91)
![CleanShot 2024-09-10 at 16 22 57@2x](https://github.com/user-attachments/assets/c2925ca4-aef9-49b2-98b2-dee4c05eb591)
